### PR TITLE
change dot const to u8

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -73,7 +73,7 @@ impl Dir {
         let res = unsafe {
             libc::readlinkat(self.as_raw_fd(),
                         path.as_ptr(),
-                        buf.as_mut_ptr() as *mut i8, buf.len())
+                        buf.as_mut_ptr(), buf.len())
         };
         if res < 0 {
             Err(io::Error::last_os_error())

--- a/src/list.rs
+++ b/src/list.rs
@@ -11,8 +11,8 @@ use {Dir, Entry, SimpleType};
 
 
 // We have such weird constants because C types are ugly
-const DOT: [i8; 2] = [b'.' as i8, 0];
-const DOTDOT: [i8; 3] = [b'.' as i8, b'.' as i8, 0];
+const DOT: [u8; 2] = [b'.' as u8, 0];
+const DOTDOT: [u8; 3] = [b'.' as u8, b'.' as u8, 0];
 
 
 /// Iterator over directory entries


### PR DESCRIPTION
Hi @tailhook, 
Couldn't help but notice that `openat` doesn't compile. 
After this change it does.
Ran the tests, nothing seems negatively affected by this. 