### PR TITLE
use c_char instead of i8

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -73,7 +73,7 @@ impl Dir {
         let res = unsafe {
             libc::readlinkat(self.as_raw_fd(),
                         path.as_ptr(),
-                        buf.as_mut_ptr() as *mut i8, buf.len())
+                        buf.as_mut_ptr() as *mut libc::c_char, buf.len())
         };
         if res < 0 {
             Err(io::Error::last_os_error())

--- a/src/list.rs
+++ b/src/list.rs
@@ -11,8 +11,8 @@ use {Dir, Entry, SimpleType};
 
 
 // We have such weird constants because C types are ugly
-const DOT: [i8; 2] = [b'.' as i8, 0];
-const DOTDOT: [i8; 3] = [b'.' as i8, b'.' as i8, 0];
+const DOT: [libc::c_char; 2] = [b'.' as libc::c_char, 0];
+const DOTDOT: [libc::c_char; 3] = [b'.' as libc::c_char, b'.' as libc::c_char, 0];
 
 
 /// Iterator over directory entries


### PR DESCRIPTION
I just realized the problem of openat not compiling wasn't `i8` vs `u8` as I thought in #3 , but rather the use of the underlying type instead of the alias provided by `libc`, since apparently it wasn't the same for all platforms.