### PR TITLE
dir: do not return `AT_FDCWD` to avoid EBADF

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -1,7 +1,6 @@
 use std::io;
 use std::ptr;
 use std::ffi::{CStr, OsStr};
-use std::os::unix::io::AsRawFd;
 use std::os::unix::ffi::OsStrExt;
 
 use libc;
@@ -10,8 +9,8 @@ use {Dir, Entry, SimpleType};
 
 
 // We have such weird constants because C types are ugly
-const DOT: [libc::c_char; 2] = [b'.' as libc::c_char, 0];
-const DOTDOT: [libc::c_char; 3] = [b'.' as libc::c_char, b'.' as libc::c_char, 0];
+pub(crate) const DOT: [libc::c_char; 2] = [b'.' as libc::c_char, 0];
+pub(crate) const DOTDOT: [libc::c_char; 3] = [b'.' as libc::c_char, b'.' as libc::c_char, 0];
 
 
 /// Iterator over directory entries
@@ -69,7 +68,7 @@ impl DirIter {
 
 pub fn open_dir(dir: &Dir, path: &CStr) -> io::Result<DirIter> {
     let dir_fd = unsafe {
-        libc::openat(dir.as_raw_fd(), path.as_ptr(), libc::O_DIRECTORY)
+        libc::openat(dir.0, path.as_ptr(), libc::O_DIRECTORY)
     };
     if dir_fd < 0 {
         Err(io::Error::last_os_error())


### PR DESCRIPTION
This reworks raw-fd conversion for `AT_FDCWD`, to avoid returning an
invalid file descriptor out of `Dir::cwd()`.
It also adds few tests to cover basic cwd conversion cases.