### PR TITLE
Add support for bionic libc (android)

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -37,12 +37,12 @@ unsafe fn errno_location() -> *mut libc::c_int {
     libc::__errno_location()
 }
 
-#[cfg(any(target_os="openbsd", target_os="netbsd"))]
+#[cfg(any(target_os="openbsd", target_os="netbsd", target_os="android"))]
 unsafe fn errno_location() -> *mut libc::c_int {
     libc::__errno()
 }
 
-#[cfg(not(any(target_os="linux", target_os="openbsd", target_os="netbsd")))]
+#[cfg(not(any(target_os="linux", target_os="openbsd", target_os="netbsd", target_os="android")))]
 unsafe fn errno_location() -> *mut libc::c_int {
     libc::__error()
 }


### PR DESCRIPTION
With this patch `openat` compiles on Android
Fixes #12 
![screenshot_termux_20181213-141022](https://user-images.githubusercontent.com/2265184/49939260-fe76d780-fee4-11e8-8faa-50a698d27cc7.png)