### PR TITLE
Add support for fuchsia libc

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -32,7 +32,7 @@ impl Entry {
     }
 }
 
-#[cfg(target_os="linux")]
+#[cfg(any(target_os="linux", target_os="fuchsia"))]
 unsafe fn errno_location() -> *mut libc::c_int {
     libc::__errno_location()
 }
@@ -42,7 +42,7 @@ unsafe fn errno_location() -> *mut libc::c_int {
     libc::__errno()
 }
 
-#[cfg(not(any(target_os="linux", target_os="openbsd", target_os="netbsd", target_os="android")))]
+#[cfg(not(any(target_os="linux", target_os="openbsd", target_os="netbsd", target_os="android", target_os="fuchsia")))]
 unsafe fn errno_location() -> *mut libc::c_int {
     libc::__error()
 }


### PR DESCRIPTION
Fuchsia uses the same signature for errno as Linux:
https://github.com/rust-lang/libc/blob/bf85aa6dfc5b782eb372b987fbbe2bc50e27c61b/src/fuchsia/mod.rs#L3887