### PR TITLE
Add macOS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ jobs:
     rust: beta
   - os: linux
     rust: nightly
+  - os: macos
+    osx_image: xcode9.3
+    rust: stable
 
   # deploy
   - stage: publish

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -12,6 +12,11 @@ use list::{DirIter, open_dir};
 
 use {Dir, AsPath};
 
+#[cfg(target_os="macos")]
+const BASE_OPEN_FLAGS: libc::c_int = libc::O_CLOEXEC;
+#[cfg(not(target_os="macos"))]
+const BASE_OPEN_FLAGS: libc::c_int = libc::O_PATH|libc::O_CLOEXEC;
+
 impl Dir {
     /// Creates a directory descriptor that resolves paths relative to current
     /// working directory (AT_FDCWD)
@@ -34,7 +39,7 @@ impl Dir {
 
     fn _open(path: &CStr) -> io::Result<Dir> {
         let fd = unsafe {
-            libc::open(path.as_ptr(), libc::O_PATH|libc::O_CLOEXEC)
+            libc::open(path.as_ptr(), BASE_OPEN_FLAGS)
         };
         if fd < 0 {
             Err(io::Error::last_os_error())
@@ -59,7 +64,7 @@ impl Dir {
         let fd = unsafe {
             libc::openat(self.0,
                         path.as_ptr(),
-                        libc::O_PATH|libc::O_CLOEXEC|libc::O_NOFOLLOW)
+                        BASE_OPEN_FLAGS|libc::O_NOFOLLOW)
         };
         if fd < 0 {
             Err(io::Error::last_os_error())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@
 //! *Note2: The constructor `Dir::cwd()` is deprecated, and it's recommended
 //! to use `Dir::open(".")` instead.*
 //!
+//! *Note3: Some OS's (e.g., macOS) do not provide `O_PATH`, in which case the
+//! file descriptor is of regular type.*
+//!
 //! Most other operations are done on `Dir` object and are executed relative
 //! to it:
 //!


### PR DESCRIPTION
This crate fails to build on macOS because the `O_PATH` flag is not available on that OS. As far as I can tell, everything is fine if we just avoid it on Macs. This PR also adds a macOS build to the Travis CI build matrix to ensure that the build continues to work going forward.