### PR TITLE
Add methods to query the directory itself

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -378,6 +378,18 @@ impl Dir {
         }
     }
 
+    /// Returns the metadata of the directory itself.
+    pub fn self_metadata(&self) -> io::Result<Metadata> {
+        unsafe {
+            let mut stat = mem::zeroed();
+            let res = libc::fstat(self.0, &mut stat);
+            if res < 0 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(metadata::new(stat))
+            }
+        }
+    }
 }
 
 /// Rename (move) a file between directories

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -57,7 +57,9 @@ impl Dir {
 
     /// List this dir
     pub fn list_self(&self) -> io::Result<DirIter> {
-        open_dirfd(self.0)
+        unsafe {
+            open_dirfd(libc::dup(self.0))
+        }
     }
 
     /// Open subdirectory

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -8,7 +8,7 @@ use std::path::{PathBuf};
 
 use libc;
 use metadata::{self, Metadata};
-use list::{DirIter, open_dir};
+use list::{DirIter, open_dir, open_dirfd};
 
 use {Dir, AsPath};
 
@@ -50,9 +50,14 @@ impl Dir {
 
     /// List subdirectory of this dir
     ///
-    /// You can list directory itself if `"."` is specified as path.
+    /// You can list directory itself with `list_self`.
     pub fn list_dir<P: AsPath>(&self, path: P) -> io::Result<DirIter> {
         open_dir(self, to_cstr(path)?.as_ref())
+    }
+
+    /// List this dir
+    pub fn list_self(&self) -> io::Result<DirIter> {
+        open_dirfd(self.0)
     }
 
     /// Open subdirectory

--- a/src/list.rs
+++ b/src/list.rs
@@ -66,6 +66,15 @@ impl DirIter {
     }
 }
 
+pub fn open_dirfd(fd: libc::c_int) -> io::Result<DirIter> {
+    let dir = unsafe { libc::fdopendir(fd) };
+    if dir == std::ptr::null_mut() {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(DirIter { dir: dir })
+    }
+}
+
 pub fn open_dir(dir: &Dir, path: &CStr) -> io::Result<DirIter> {
     let dir_fd = unsafe {
         libc::openat(dir.0, path.as_ptr(), libc::O_DIRECTORY|libc::O_CLOEXEC)
@@ -73,12 +82,7 @@ pub fn open_dir(dir: &Dir, path: &CStr) -> io::Result<DirIter> {
     if dir_fd < 0 {
         Err(io::Error::last_os_error())
     } else {
-        let dir = unsafe { libc::fdopendir(dir_fd) };
-        if dir == ptr::null_mut() {
-            Err(io::Error::last_os_error())
-        } else {
-            Ok(DirIter { dir: dir })
-        }
+        open_dirfd(dir_fd)
     }
 }
 


### PR DESCRIPTION
I'm using `openat` to access the directory which is used as the mount point of a fuse filesystem. Unfortunately, during the initialization I cannot simply call `dir.metadata(".")` or `dir.list_dir(".")` because that would access the fuse fs itself instead of the directory! (speaking of macOS, not sure about Linux tho)

Therefore, I propose new methods `self_metadata` (`fstat` under the hood) and `list_self` to query the directory itself.

PS: this makes me wonder if deprecating `cwd` is a good decision tho. If the cwd is some directory A, but later a fs is mounted on A, `Dir::open(".")` will probably open the root of the fs instead of the directory A. I haven't tested so I'm not sure about this.

btw, do you have a better name?