### PR TITLE
Only use O_PATH on Linux, use O_DIRECTORY on FreeBSD

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -14,7 +14,9 @@ use {Dir, AsPath};
 
 #[cfg(target_os="macos")]
 const BASE_OPEN_FLAGS: libc::c_int = libc::O_CLOEXEC;
-#[cfg(not(target_os="macos"))]
+#[cfg(target_os="freebsd")]
+const BASE_OPEN_FLAGS: libc::c_int = libc::O_DIRECTORY|libc::O_CLOEXEC;
+#[cfg(not(any(target_os="macos", target_os="freebsd")))]
 const BASE_OPEN_FLAGS: libc::c_int = libc::O_PATH|libc::O_CLOEXEC;
 
 impl Dir {
@@ -546,6 +548,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(target_os="freebsd", should_panic(expected="Not a directory"))]
     fn test_open_file() {
         Dir::open("src/lib.rs").unwrap();
     }

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -12,12 +12,12 @@ use list::{DirIter, open_dir, open_dirfd};
 
 use {Dir, AsPath};
 
-#[cfg(target_os="macos")]
-const BASE_OPEN_FLAGS: libc::c_int = libc::O_CLOEXEC;
+#[cfg(target_os="linux")]
+const BASE_OPEN_FLAGS: libc::c_int = libc::O_PATH|libc::O_CLOEXEC;
 #[cfg(target_os="freebsd")]
 const BASE_OPEN_FLAGS: libc::c_int = libc::O_DIRECTORY|libc::O_CLOEXEC;
-#[cfg(not(any(target_os="macos", target_os="freebsd")))]
-const BASE_OPEN_FLAGS: libc::c_int = libc::O_PATH|libc::O_CLOEXEC;
+#[cfg(not(any(target_os="linux", target_os="freebsd")))]
+const BASE_OPEN_FLAGS: libc::c_int = libc::O_CLOEXEC;
 
 impl Dir {
     /// Creates a directory descriptor that resolves paths relative to current


### PR DESCRIPTION
`O_DIRECTORY` checks that you're opening a directory. It's also available on Linux, but the manpage there says not to use it (o_0)