### PR TITLE
Document O_NOFOLLOW behavior for Dir methods

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -65,6 +65,11 @@ impl Dir {
     }
 
     /// Open subdirectory
+    ///
+    /// Note that this method does not resolve symlinks by default, so you may have to call
+    /// [`read_link`] to resolve the real path first.
+    ///
+    /// [`read_link`]: #method.read_link
     pub fn sub_dir<P: AsPath>(&self, path: P) -> io::Result<Dir> {
         self._sub_dir(to_cstr(path)?.as_ref())
     }
@@ -103,12 +108,22 @@ impl Dir {
     }
 
     /// Open file for reading in this directory
+    ///
+    /// Note that this method does not resolve symlinks by default, so you may have to call
+    /// [`read_link`] to resolve the real path first.
+    ///
+    /// [`read_link`]: #method.read_link
     pub fn open_file<P: AsPath>(&self, path: P) -> io::Result<File> {
         self._open_file(to_cstr(path)?.as_ref(),
             libc::O_RDONLY, 0)
     }
 
     /// Open file for writing, create if necessary, truncate on open
+    ///
+    /// Note that this method does not resolve symlinks by default, so you may have to call
+    /// [`read_link`] to resolve the real path first.
+    ///
+    /// [`read_link`]: #method.read_link
     pub fn write_file<P: AsPath>(&self, path: P, mode: libc::mode_t)
         -> io::Result<File>
     {
@@ -118,6 +133,11 @@ impl Dir {
     }
 
     /// Open file for append, create if necessary
+    ///
+    /// Note that this method does not resolve symlinks by default, so you may have to call
+    /// [`read_link`] to resolve the real path first.
+    ///
+    /// [`read_link`]: #method.read_link
     pub fn append_file<P: AsPath>(&self, path: P, mode: libc::mode_t)
         -> io::Result<File>
     {
@@ -129,6 +149,11 @@ impl Dir {
     /// Create file for writing (and truncate) in this directory
     ///
     /// Deprecated alias for `write_file`
+    ///
+    /// Note that this method does not resolve symlinks by default, so you may have to call
+    /// [`read_link`] to resolve the real path first.
+    ///
+    /// [`read_link`]: #method.read_link
     #[deprecated(since="0.1.7", note="please use `write_file` instead")]
     pub fn create_file<P: AsPath>(&self, path: P, mode: libc::mode_t)
         -> io::Result<File>
@@ -161,6 +186,11 @@ impl Dir {
     /// Currently, we recommend to fallback on any error if this operation
     /// can't be accomplished rather than relying on specific error codes,
     /// because semantics of errors are very ugly.
+    ///
+    /// Note that this method does not resolve symlinks by default, so you may have to call
+    /// [`read_link`] to resolve the real path first.
+    ///
+    /// [`read_link`]: #method.read_link
     #[cfg(target_os="linux")]
     pub fn new_unnamed_file(&self, mode: libc::mode_t)
         -> io::Result<File>
@@ -244,6 +274,11 @@ impl Dir {
     /// respect to other threads and processes.
     ///
     /// Technically it means passing `O_EXCL` flag to open.
+    ///
+    /// Note that this method does not resolve symlinks by default, so you may have to call
+    /// [`read_link`] to resolve the real path first.
+    ///
+    /// [`read_link`]: #method.read_link
     pub fn new_file<P: AsPath>(&self, path: P, mode: libc::mode_t)
         -> io::Result<File>
     {
@@ -253,6 +288,11 @@ impl Dir {
     }
 
     /// Open file for reading and writing without truncation, create if needed
+    ///
+    /// Note that this method does not resolve symlinks by default, so you may have to call
+    /// [`read_link`] to resolve the real path first.
+    ///
+    /// [`read_link`]: #method.read_link
     pub fn update_file<P: AsPath>(&self, path: P, mode: libc::mode_t)
         -> io::Result<File>
     {
@@ -376,6 +416,11 @@ impl Dir {
     }
 
     /// Returns metadata of an entry in this directory
+    ///
+    /// Note that this method does not resolve symlinks by default, so you may have to call
+    /// [`read_link`] to resolve the real path first.
+    ///
+    /// [`read_link`]: #method.read_link
     pub fn metadata<P: AsPath>(&self, path: P) -> io::Result<Metadata> {
         self._stat(to_cstr(path)?.as_ref(), libc::AT_SYMLINK_NOFOLLOW)
     }

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -273,11 +273,6 @@ impl Dir {
     /// respect to other threads and processes.
     ///
     /// Technically it means passing `O_EXCL` flag to open.
-    ///
-    /// Note that this method does not resolve symlinks by default, so you may have to call
-    /// [`read_link`] to resolve the real path first.
-    ///
-    /// [`read_link`]: #method.read_link
     pub fn new_file<P: AsPath>(&self, path: P, mode: libc::mode_t)
         -> io::Result<File>
     {

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -120,10 +120,12 @@ impl Dir {
 
     /// Open file for writing, create if necessary, truncate on open
     ///
-    /// Note that this method does not resolve symlinks by default, so you may have to call
-    /// [`read_link`] to resolve the real path first.
+    /// If there exists a symlink at the destination path, this method will fail. In that case, you
+    /// will need to remove the symlink before calling this method. If you are on Linux, you can
+    /// alternatively create an unnamed file with [`new_unnamed_file`] and then rename it,
+    /// clobbering the symlink at the destination.
     ///
-    /// [`read_link`]: #method.read_link
+    /// [`new_unnamed_file`]: #method.new_unnamed_file
     pub fn write_file<P: AsPath>(&self, path: P, mode: libc::mode_t)
         -> io::Result<File>
     {
@@ -134,8 +136,8 @@ impl Dir {
 
     /// Open file for append, create if necessary
     ///
-    /// Note that this method does not resolve symlinks by default, so you may have to call
-    /// [`read_link`] to resolve the real path first.
+    /// If there exists a symlink at the destination path, this method will fail. In that case, you
+    /// will need to call [`read_link`] to resolve the real path first.
     ///
     /// [`read_link`]: #method.read_link
     pub fn append_file<P: AsPath>(&self, path: P, mode: libc::mode_t)
@@ -150,10 +152,12 @@ impl Dir {
     ///
     /// Deprecated alias for `write_file`
     ///
-    /// Note that this method does not resolve symlinks by default, so you may have to call
-    /// [`read_link`] to resolve the real path first.
+    /// If there exists a symlink at the destination path, this method will fail. In that case, you
+    /// will need to remove the symlink before calling this method. If you are on Linux, you can
+    /// alternatively create an unnamed file with [`new_unnamed_file`] and then rename it,
+    /// clobbering the symlink at the destination.
     ///
-    /// [`read_link`]: #method.read_link
+    /// [`new_unnamed_file`]: #method.new_unnamed_file
     #[deprecated(since="0.1.7", note="please use `write_file` instead")]
     pub fn create_file<P: AsPath>(&self, path: P, mode: libc::mode_t)
         -> io::Result<File>
@@ -289,8 +293,8 @@ impl Dir {
 
     /// Open file for reading and writing without truncation, create if needed
     ///
-    /// Note that this method does not resolve symlinks by default, so you may have to call
-    /// [`read_link`] to resolve the real path first.
+    /// If there exists a symlink at the destination path, this method will fail. In that case, you
+    /// will need to call [`read_link`] to resolve the real path first.
     ///
     /// [`read_link`]: #method.read_link
     pub fn update_file<P: AsPath>(&self, path: P, mode: libc::mode_t)

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -190,11 +190,6 @@ impl Dir {
     /// Currently, we recommend to fallback on any error if this operation
     /// can't be accomplished rather than relying on specific error codes,
     /// because semantics of errors are very ugly.
-    ///
-    /// Note that this method does not resolve symlinks by default, so you may have to call
-    /// [`read_link`] to resolve the real path first.
-    ///
-    /// [`read_link`]: #method.read_link
     #[cfg(target_os="linux")]
     pub fn new_unnamed_file(&self, mode: libc::mode_t)
         -> io::Result<File>

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -411,8 +411,9 @@ impl Dir {
 
     /// Returns metadata of an entry in this directory
     ///
-    /// Note that this method does not resolve symlinks by default, so you may have to call
-    /// [`read_link`] to resolve the real path first.
+    /// If the destination path is a symlink, this will return the metadata of the symlink itself.
+    /// If you would like to follow the symlink and return the metadata of the target, you will
+    /// have to call [`read_link`] to resolve the real path first.
     ///
     /// [`read_link`]: #method.read_link
     pub fn metadata<P: AsPath>(&self, path: P) -> io::Result<Metadata> {


### PR DESCRIPTION
### Changed

* Update documentation for `sub_dir`, `open_file`, `write_file`, `append_file`, `create_file`, `update_file`, and `metadata` methods.

This pull request clarifies the documentation for several `Dir` methods to note that they have `O_NOFOLLOW` enabled by default and that users will need to call `Dir::read_link()` first if they would like to follow symlinks.

Closes #26.