### PR TITLE
Add DirIter repositioning functions

### DIFF
--- a/src/list.rs
+++ b/src/list.rs
@@ -64,6 +64,28 @@ impl DirIter {
         }
         return Ok(Some(&*entry));
     }
+
+    /// Returns the current directory iterator position. The result should be handled as opaque value
+    pub fn current_position(&self) -> io::Result<libc::c_long> {
+        let pos = unsafe { libc::telldir(self.dir) };
+
+        if pos == -1 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(pos)
+        }
+    }
+
+    // note the C-API does not report errors for seekdir/rewinddir, thus we don't do as well.
+    /// Sets the current directory iterator position to some location queried by 'current_position()'
+    pub fn seek(&self, position: libc::c_long) {
+        unsafe { libc::seekdir(self.dir, position) };
+    }
+
+    /// Resets the current directory iterator position to the beginning
+    pub fn rewind(&self) {
+        unsafe { libc::rewinddir(self.dir) };
+    }
 }
 
 pub fn open_dirfd(fd: libc::c_int) -> io::Result<DirIter> {

--- a/src/list.rs
+++ b/src/list.rs
@@ -21,6 +21,9 @@ pub struct DirIter {
     dir: *mut libc::DIR,
 }
 
+/// Position in a DirIter as obtained by 'DirIter::current_position()'
+///
+/// The position is only valid for the DirIter it was retrieved from.
 pub struct DirPosition {
     pos: libc::c_long,
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -21,6 +21,10 @@ pub struct DirIter {
     dir: *mut libc::DIR,
 }
 
+pub struct DirPosition {
+    pos: libc::c_long,
+}
+
 impl Entry {
     /// Returns the file name of this entry
     pub fn file_name(&self) -> &OsStr {
@@ -66,20 +70,20 @@ impl DirIter {
     }
 
     /// Returns the current directory iterator position. The result should be handled as opaque value
-    pub fn current_position(&self) -> io::Result<libc::c_long> {
+    pub fn current_position(&self) -> io::Result<DirPosition> {
         let pos = unsafe { libc::telldir(self.dir) };
 
         if pos == -1 {
             Err(io::Error::last_os_error())
         } else {
-            Ok(pos)
+            Ok(DirPosition { pos })
         }
     }
 
     // note the C-API does not report errors for seekdir/rewinddir, thus we don't do as well.
     /// Sets the current directory iterator position to some location queried by 'current_position()'
-    pub fn seek(&self, position: libc::c_long) {
-        unsafe { libc::seekdir(self.dir, position) };
+    pub fn seek(&self, position: DirPosition) {
+        unsafe { libc::seekdir(self.dir, position.pos) };
     }
 
     /// Resets the current directory iterator position to the beginning


### PR DESCRIPTION
DirIter missed functionality for the tell/rewind/seek functions. This adds these.

I had some slight reservations if it is ok to reposition an iterator, but since this is explicit there should be no problem.