### PR TITLE
add accessors for the underlying stat data

### DIFF
--- a/src/filetype.rs
+++ b/src/filetype.rs
@@ -7,6 +7,8 @@ use std::fs::Metadata;
 /// this simplified enum that works for many appalications.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SimpleType {
+    /// Entry is of unknown type
+    Unknown,
     /// Entry is a symlink
     Symlink,
     /// Entry is a directory

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -2,6 +2,7 @@ use std::fs::Permissions;
 use std::os::unix::fs::PermissionsExt;
 
 use libc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::SimpleType;
 
@@ -45,10 +46,88 @@ impl Metadata {
     pub fn len(&self) -> u64 {
         self.stat.st_size as u64
     }
+    /// Return low level file type, if available
+    pub fn file_type(&self) -> Option<u32> {
+        Some(self.stat.st_mode & libc::S_IFMT)
+    }
+    /// Return device node, if available
+    pub fn ino(&self) -> Option<libc::ino_t> {
+        Some(self.stat.st_ino)
+    }
+    /// Return device node major of the file, if available
+    pub fn dev_major(&self) -> Option<u64> {
+        Some(unsafe { libc::major(self.stat.st_dev) } as u64)
+    }
+    /// Return device node minor of the file, if available
+    pub fn dev_minor(&self) -> Option<u64> {
+        Some(unsafe { libc::minor(self.stat.st_dev) } as u64)
+    }
+    /// Return device node major of an device descriptor, if available
+    pub fn rdev_major(&self) -> Option<u64> {
+        match self.file_type()? {
+            libc::S_IFBLK | libc::S_IFCHR => Some(unsafe { libc::major(self.stat.st_rdev) } as u64),
+            _ => None,
+        }
+    }
+    /// Return device node minor of an device descriptor, if available
+    pub fn rdev_minor(&self) -> Option<u64> {
+        match self.file_type()? {
+            libc::S_IFBLK | libc::S_IFCHR => Some(unsafe { libc::minor(self.stat.st_rdev) } as u64),
+            _ => None,
+        }
+    }
+    /// Return preferered I/O Blocksize, if available
+    pub fn blksize(&self) -> Option<u32> {
+        Some(self.stat.st_blksize as u32)
+    }
+    /// Return the number of 512 bytes blocks, if available
+    pub fn blocks(&self) -> Option<u64> {
+        Some(self.stat.st_blocks as u64)
+    }
+    /// Returns file size (same as len() but Option), if available
+    pub fn size(&self) -> Option<u64> {
+        Some(self.stat.st_size as u64)
+    }
+    /// Returns number of hard-links, if available
+    pub fn nlink(&self) -> Option<u32> {
+        Some(self.stat.st_nlink as u32)
+    }
+    /// Returns user id, if available
+    pub fn uid(&self) -> Option<u32> {
+        Some(self.stat.st_uid as u32)
+    }
+    /// Returns group id, if available
+    pub fn gid(&self) -> Option<u32> {
+        Some(self.stat.st_gid as u32)
+    }
+    /// Returns mode bits, if available
+    pub fn file_mode(&self) -> Option<u32> {
+        Some(self.stat.st_mode & 0o7777)
+    }
+    /// Returns last access time, if available
+    pub fn atime(&self) -> Option<SystemTime> {
+        Some(unix_systemtime(self.stat.st_atime, self.stat.st_atime_nsec))
+    }
+    /// Returns creation, if available
+    pub fn btime(&self) -> Option<SystemTime> {
+        None
+    }
+    /// Returns last status change time, if available
+    pub fn ctime(&self) -> Option<SystemTime> {
+        Some(unix_systemtime(self.stat.st_ctime, self.stat.st_ctime_nsec))
+    }
+    /// Returns last modification time, if available
+    pub fn mtime(&self) -> Option<SystemTime> {
+        Some(unix_systemtime(self.stat.st_mtime, self.stat.st_mtime_nsec))
+    }
 }
 
 pub fn new(stat: libc::stat) -> Metadata {
     Metadata { stat: stat }
+}
+
+fn unix_systemtime(sec: libc::time_t, nsec: i64) -> SystemTime {
+    UNIX_EPOCH + Duration::from_secs(sec as u64) + Duration::from_nanos(nsec as u64)
 }
 
 #[cfg(test)]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -51,8 +51,8 @@ impl Metadata {
         Some(self.stat.st_mode as u32 & libc::S_IFMT as u32)
     }
     /// Return device node, if available
-    pub fn ino(&self) -> Option<libc::ino_t> {
-        Some(self.stat.st_ino)
+    pub fn ino(&self) -> Option<u64> {
+        Some(self.stat.st_ino as u64)
     }
     /// Return device node major of the file, if available
     pub fn dev_major(&self) -> Option<u32> {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -55,24 +55,24 @@ impl Metadata {
         Some(self.stat.st_ino)
     }
     /// Return device node major of the file, if available
-    pub fn dev_major(&self) -> Option<u64> {
-        Some(unsafe { libc::major(self.stat.st_dev) } as u64)
+    pub fn dev_major(&self) -> Option<u32> {
+        Some(unsafe { libc::major(self.stat.st_dev) })
     }
     /// Return device node minor of the file, if available
-    pub fn dev_minor(&self) -> Option<u64> {
-        Some(unsafe { libc::minor(self.stat.st_dev) } as u64)
+    pub fn dev_minor(&self) -> Option<u32> {
+        Some(unsafe { libc::minor(self.stat.st_dev) })
     }
     /// Return device node major of an device descriptor, if available
-    pub fn rdev_major(&self) -> Option<u64> {
+    pub fn rdev_major(&self) -> Option<u32> {
         match self.file_type()? {
-            libc::S_IFBLK | libc::S_IFCHR => Some(unsafe { libc::major(self.stat.st_rdev) } as u64),
+            libc::S_IFBLK | libc::S_IFCHR => Some(unsafe { libc::major(self.stat.st_rdev) }),
             _ => None,
         }
     }
     /// Return device node minor of an device descriptor, if available
-    pub fn rdev_minor(&self) -> Option<u64> {
+    pub fn rdev_minor(&self) -> Option<u32> {
         match self.file_type()? {
-            libc::S_IFBLK | libc::S_IFCHR => Some(unsafe { libc::minor(self.stat.st_rdev) } as u64),
+            libc::S_IFBLK | libc::S_IFCHR => Some(unsafe { libc::minor(self.stat.st_rdev) }),
             _ => None,
         }
     }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -47,12 +47,12 @@ impl Metadata {
         self.stat.st_size as u64
     }
     /// Return low level file type, if available
-    pub fn file_type(&self) -> Option<u32> {
-        Some(self.stat.st_mode as u32 & libc::S_IFMT as u32)
+    pub fn file_type(&self) -> Option<libc::mode_t> {
+        Some(self.stat.st_mode & libc::S_IFMT)
     }
     /// Return device node, if available
-    pub fn ino(&self) -> Option<u64> {
-        Some(self.stat.st_ino as u64)
+    pub fn ino(&self) -> Option<libc::ino_t> {
+        Some(self.stat.st_ino)
     }
     /// Return device node major of the file, if available
     pub fn dev_major(&self) -> Option<u32> {
@@ -77,32 +77,32 @@ impl Metadata {
         }
     }
     /// Return preferered I/O Blocksize, if available
-    pub fn blksize(&self) -> Option<u32> {
-        Some(self.stat.st_blksize as u32)
+    pub fn blksize(&self) -> Option<libc::blksize_t> {
+        Some(self.stat.st_blksize)
     }
     /// Return the number of 512 bytes blocks, if available
-    pub fn blocks(&self) -> Option<u64> {
-        Some(self.stat.st_blocks as u64)
+    pub fn blocks(&self) -> Option<libc::blkcnt_t> {
+        Some(self.stat.st_blocks)
     }
     /// Returns file size (same as len() but Option), if available
-    pub fn size(&self) -> Option<u64> {
-        Some(self.stat.st_size as u64)
+    pub fn size(&self) -> Option<libc::off_t> {
+        Some(self.stat.st_size)
     }
     /// Returns number of hard-links, if available
-    pub fn nlink(&self) -> Option<u32> {
-        Some(self.stat.st_nlink as u32)
+    pub fn nlink(&self) -> Option<libc::nlink_t> {
+        Some(self.stat.st_nlink)
     }
     /// Returns user id, if available
-    pub fn uid(&self) -> Option<u32> {
-        Some(self.stat.st_uid as u32)
+    pub fn uid(&self) -> Option<libc::uid_t> {
+        Some(self.stat.st_uid)
     }
     /// Returns group id, if available
-    pub fn gid(&self) -> Option<u32> {
-        Some(self.stat.st_gid as u32)
+    pub fn gid(&self) -> Option<libc::gid_t> {
+        Some(self.stat.st_gid)
     }
     /// Returns mode bits, if available
-    pub fn file_mode(&self) -> Option<u32> {
-        Some(self.stat.st_mode as u32 & 0o7777)
+    pub fn file_mode(&self) -> Option<libc::mode_t> {
+        Some(self.stat.st_mode & 0o7777)
     }
     /// Returns last access time, if available
     pub fn atime(&self) -> Option<SystemTime> {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -18,11 +18,11 @@ pub struct Metadata {
 impl Metadata {
     /// Returns simplified type of the directory entry
     pub fn simple_type(&self) -> SimpleType {
-        let typ = self.stat.st_mode & libc::S_IFMT;
-        match typ {
+        match self.file_type().unwrap_or(0) {
             libc::S_IFREG => SimpleType::File,
             libc::S_IFDIR => SimpleType::Dir,
             libc::S_IFLNK => SimpleType::Symlink,
+            0 => SimpleType::Unknown,
             _ => SimpleType::Other,
         }
     }


### PR DESCRIPTION
This anticipates the statx() interface I'll add soon.

Breaking change: Adds a 'SimpleType::Unknown' which can be returned when the filetype can't be
determinded. Code matching on SimpleType may add a clause for this when there is no catch-all.