### PR TITLE
Store inode in Entry, add accessor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ pub struct Dir(RawFd);
 pub struct Entry {
     name: CString,
     file_type: Option<SimpleType>,
+    ino: libc::ino_t,
 }
 
 #[cfg(test)]

--- a/src/list.rs
+++ b/src/list.rs
@@ -37,6 +37,10 @@ impl Entry {
     pub fn simple_type(&self) -> Option<SimpleType> {
         self.file_type
     }
+    /// Returns the inode number of this entry
+    pub fn inode(&self) -> libc::ino_t {
+        self.ino
+    }
 }
 
 #[cfg(any(target_os="linux", target_os="fuchsia"))]
@@ -136,6 +140,7 @@ impl Iterator for DirIter {
                                 libc::DT_LNK => Some(SimpleType::Symlink),
                                 _ => Some(SimpleType::Other),
                             },
+                            ino: e.d_ino,
                         }));
                     }
                 }


### PR DESCRIPTION
the d_ino field is mandatory in POSIX and clients (me) really need it when passing data
around. Keeping it in the Entry saves an extra stat()/metadata query.