### PR TITLE
Add/Refactor Dir::list() -> DirIter ctor

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -7,8 +7,8 @@ use std::os::unix::ffi::{OsStringExt};
 use std::path::{PathBuf};
 
 use libc;
+use crate::list::{open_dirfd, DirIter};
 use crate::metadata::{self, Metadata};
-use crate::list::{DirIter, open_dir, open_dirfd};
 
 use crate::{Dir, AsPath};
 
@@ -53,15 +53,20 @@ impl Dir {
     /// List subdirectory of this dir
     ///
     /// You can list directory itself with `list_self`.
+    // TODO(cehteh): may be deprecated in favor of list()
     pub fn list_dir<P: AsPath>(&self, path: P) -> io::Result<DirIter> {
-        open_dir(self, to_cstr(path)?.as_ref())
+        self.sub_dir(path)?.list()
     }
 
     /// List this dir
+    // TODO(cehteh): may be deprecated in favor of list()
     pub fn list_self(&self) -> io::Result<DirIter> {
-        unsafe {
-            open_dirfd(libc::dup(self.0))
-        }
+        self.try_clone()?.list()
+    }
+
+    /// Create a DirIter from a Dir
+    pub fn list(self) -> io::Result<DirIter> {
+        open_dirfd(self.0)
     }
 
     /// Open subdirectory

--- a/src/list.rs
+++ b/src/list.rs
@@ -5,8 +5,7 @@ use std::os::unix::ffi::OsStrExt;
 
 use libc;
 
-use crate::{Dir, Entry, SimpleType};
-
+use crate::{Entry, SimpleType};
 
 // We have such weird constants because C types are ugly
 const DOT: [libc::c_char; 2] = [b'.' as libc::c_char, 0];
@@ -101,17 +100,6 @@ pub fn open_dirfd(fd: libc::c_int) -> io::Result<DirIter> {
         Err(io::Error::last_os_error())
     } else {
         Ok(DirIter { dir: dir })
-    }
-}
-
-pub fn open_dir(dir: &Dir, path: &CStr) -> io::Result<DirIter> {
-    let dir_fd = unsafe {
-        libc::openat(dir.0, path.as_ptr(), libc::O_DIRECTORY|libc::O_CLOEXEC)
-    };
-    if dir_fd < 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        open_dirfd(dir_fd)
     }
 }
 


### PR DESCRIPTION
dir.list() consumes the dir and creates a DirIter. The underlying 'dup()' operation now
becomes explicit, one may need to call try_clone() first.

the list_self() and list_dir() using this now but are merely convinience wrappers and may (or
may not) deprecated in future.

Rationale: this simplifies the code a bit (list::open_dir() removed) and is closer to the low
level semantics.